### PR TITLE
create scroll method

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 import requests_mock
 
 from datetime import datetime
@@ -163,3 +164,76 @@ def test_wrapped_methods() -> None:
         client.delete("https://api.flare.io/hello-delete")
         assert mocker.last_request.url == "https://api.flare.io/hello-delete"
         assert mocker.last_request.headers["Authorization"] == "Bearer test-token-hello"
+
+
+def test_scroll() -> None:
+    api_client = _get_test_client()
+
+    # This should make no http call.
+    with requests_mock.Mocker() as mocker:
+        response_iterator: t.Iterator[requests.Response] = api_client.scroll(
+            method="GET",
+            url="https://api.flare.io/leaksdb/v2/sources",
+            params={
+                "from": None,
+            },
+        )
+        assert len(mocker.request_history) == 0
+
+    # First page
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "GET",
+            "https://api.flare.io/leaksdb/v2/sources",
+            json={
+                "items": [1, 2, 3],
+                "next": "second_page",
+            },
+            status_code=200,
+        )
+        resp: requests.Response = next(response_iterator)
+        assert resp.json() == {"items": [1, 2, 3], "next": "second_page"}
+
+        assert len(mocker.request_history) == 1
+        assert mocker.last_request.query == ""
+
+    # Second Page
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "GET",
+            "https://api.flare.io/leaksdb/v2/sources?from=second_page",
+            json={
+                "items": [4, 5, 6],
+                "next": "third_page",
+            },
+            status_code=200,
+        )
+        resp = next(response_iterator)
+        assert resp.json() == {"items": [4, 5, 6], "next": "third_page"}
+        assert len(mocker.request_history) == 1
+        assert mocker.last_request.query == "from=second_page"
+
+    # Third Page
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "GET",
+            "https://api.flare.io/leaksdb/v2/sources?from=third_page",
+            json={
+                "items": [7, 8, 9],
+                "next": None,
+            },
+            status_code=200,
+        )
+        resp = next(response_iterator)
+        assert resp.json() == {
+            "items": [7, 8, 9],
+            "next": None,
+        }
+        assert len(mocker.request_history) == 1
+        assert mocker.last_request.query == "from=third_page"
+
+    # We stop here.
+    with requests_mock.Mocker() as mocker:
+        with pytest.raises(StopIteration):
+            resp = next(response_iterator)
+        assert len(mocker.request_history) == 0


### PR DESCRIPTION
This adds a `scoll` method with the following params:
- `method`
- `url`
- `params`
- `json`
- `headers`

It returns a `requests.Response` iterator.

I kept it simple:
- Returns response objects, not the items.
- Does not return the cursor anywhere, its already in the response. ( hesitated yielding tuples or even returning it at the end of the generator)

Example usage (will be added to api docs):
```python
import os
import time

from flareio import FlareApiClient


api_key = os.environ.get("FLARE_API_KEY")
if not api_key:
    raise Exception("Please provide an API key")

api_client = FlareApiClient(api_key=api_key)

last_from: str | None = None
fetched_pages: int = 0

for resp in api_client.scroll(
    method="GET",
    url="https://api.flare.io/leaksdb/v2/sources",
    params={
        "from": None,
    },
):
    # Rate limiting.
    time.sleep(0.1)

    # Get results from the response
    resp_data = resp.json()
    items = resp_data.get("items")

    fetched_pages += 1
    print(f"Fetched page {fetched_pages} ({last_from=}) with {len(items)} items...")

    # Save the last "next" value.
    last_from = resp_data.get("next") or last_from

print("The last value for 'next' was", last_from)
```