### PR TITLE
allow passing path only

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ client = FlareApiClient(
 )
 
 sources = client.get(
-    "https://api.flare.io/leaksdb/v2/sources",
+    "/leaksdb/v2/sources",
 ).json()
 ```
 

--- a/flareio/api_client.py
+++ b/flareio/api_client.py
@@ -3,6 +3,7 @@ import requests
 from datetime import datetime
 from datetime import timedelta
 from flareio.exceptions import TokenError
+from urllib.parse import urljoin
 from urllib.parse import urlparse
 
 import typing as t
@@ -67,6 +68,8 @@ class FlareApiClient:
         json: t.Optional[t.Dict[str, t.Any]] = None,
         headers: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> requests.Response:
+        url = urljoin("https://api.flare.io", url)
+
         if not urlparse(url).netloc == "api.flare.io":
             raise Exception(
                 "Please only use the client to access the api.flare.io domain."

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -166,6 +166,17 @@ def test_wrapped_methods() -> None:
         assert mocker.last_request.headers["Authorization"] == "Bearer test-token-hello"
 
 
+def test_get_path_only() -> None:
+    client = _get_test_client(authenticated=True)
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "GET",
+            "https://api.flare.io/hello/test",
+            status_code=200,
+        )
+        client.get("/hello/test")
+        assert mocker.last_request.url == "https://api.flare.io/hello/test"
+
 def test_scroll() -> None:
     api_client = _get_test_client()
 


### PR DESCRIPTION
Pretty safe since we have `urlparse` right after.

Also backwards compatible because of course joining with a new scheme works lol