### PR TITLE
api_client: empty tenant_id is fine

### DIFF
--- a/flareio/api_client.py
+++ b/flareio/api_client.py
@@ -40,7 +40,7 @@ class FlareApiClient:
         tenant_id: t.Optional[str] = os.environ.get("FLARE_TENANT_ID")
         return cls(
             api_key=api_key,
-            tenant_id=int(tenant_id) if tenant_id is not None else None,
+            tenant_id=int(tenant_id) if tenant_id else None,
         )
 
     @staticmethod


### PR DESCRIPTION
Actually, setting an empty tenant id (`FLARE_TENANT_ID=""`) should be fine. It should indicate you want to use a default tenant id.