### PR TITLE
Ensure CI runs on the correct version of python and fix typing issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [
           '3.8',
@@ -20,12 +21,10 @@ jobs:
     name: Python ${{ matrix.python-version }} ${{ matrix.post-venv }}
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
     - name: Install uv
       uses: astral-sh/setup-uv@v7
+      with:
+        python-version: ${{ matrix.python-version }}
     - run: make venv
     - if: ${{ matrix.post-venv }}
       run: ${{ matrix.post-venv }}

--- a/src/flareio/api_client.py
+++ b/src/flareio/api_client.py
@@ -37,7 +37,7 @@ class FlareApiClient:
         tenant_id: t.Optional[int] = None,
         session: t.Optional[requests.Session] = None,
         api_domain: t.Optional[str] = None,
-        _auth: AuthBase | None = None,
+        _auth: t.Optional[AuthBase] = None,
         _enable_beta_features: bool = False,
     ) -> None:
         if not api_key:

--- a/src/flareio/api_client.py
+++ b/src/flareio/api_client.py
@@ -21,7 +21,7 @@ from flareio.version import __version__ as _flareio_version
 
 
 _API_DOMAIN_DEFAULT: str = "api.flare.io"
-_ALLOWED_API_DOMAINS: frozenset[str] = frozenset(
+_ALLOWED_API_DOMAINS: t.FrozenSet[str] = frozenset(
     {
         _API_DOMAIN_DEFAULT,
         "api.eu.flare.io",

--- a/src/flareio/auth.py
+++ b/src/flareio/auth.py
@@ -1,14 +1,16 @@
 from requests import PreparedRequest
 from requests.auth import AuthBase
 
+import typing as t
+
 
 class _StaticHeadersAuth(AuthBase):
     def __init__(
         self,
         *,
-        headers: dict[str, str],
+        headers: t.Dict[str, str],
     ) -> None:
-        self._headers: dict[str, str] = headers
+        self._headers: t.Dict[str, str] = headers
 
     def __call__(
         self,

--- a/src/flareio/models.py
+++ b/src/flareio/models.py
@@ -1,8 +1,10 @@
 import dataclasses
 
+import typing as t
+
 
 @dataclasses.dataclass(frozen=True)
 class ScrollEventsResult:
     metadata: dict
     event: dict
-    next: str | None
+    next: t.Optional[str]


### PR DESCRIPTION
The `python-version` matrix in `tests.yml` wasn't actually pinning the Python uv used, so every matrix entry was running tests on whatever interpreter uv picked (typically the newest available). 

This let a Python-3.9 runtime failure (`TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` from PEP 604 unions in `models.py` / `api_client.py`) pass CI despite "3.9" being green in CI.